### PR TITLE
Fix #244 - Método Pessoa::ativosVinculos modificado

### DIFF
--- a/doc/metodos_pessoa.md
+++ b/doc/metodos_pessoa.md
@@ -30,7 +30,7 @@
 
  - *tiposVinculos($unidade)*: retorna *array* com os tipos de vínculos *regulares* e também *Docente Aposentado* ('ALUNOGR', 'ALUNOPOS', 'ALUNOCEU', 'ALUNOEAD', 'ALUNOPD', 'SERVIDOR', 'ESTAGIARIORH')
 
- - *ativosVinculo($vinculo, $codundclgi)*: retorna *array* com as pessoas ativas de um tipo de vínculo e também Docente Aposentado
+ - *ativosVinculo($vinculo, $codundclgi, $contar)*: por padrão retorna *array* com as pessoas ativas de um tipo de vínculo e também Docente Aposentado, se o terceiro parâmetro *$contar* for igual a 1, retorna um *array* com o índice *total* que corresponde ao número total de pessoas do tipo de vínculo
  
  - *vinculosSetores($codpes, $codundclgi)*: retorna *array* com os vínculos e setores que a pessoa possui
  

--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -445,16 +445,25 @@ class Pessoa
      *
      * @param String $vinculo
      * @param Integer $codundclgi
+     * @param Integer $contar Default 0
      * @return void
      */
-    public static function ativosVinculo($vinculo, $codundclgi) 
+    public static function ativosVinculo($vinculo, $codundclgi, $contar = 0) 
     {
-        $query = "SELECT L.*, P.* FROM LOCALIZAPESSOA AS L 
-                    INNER JOIN PESSOA AS P ON (L.codpes = P.codpes) 
+        if ($contar == 0) {
+            $colunas = "L.*, P.*";
+            $ordem = "ORDER BY L.nompes";
+        } else {
+            $colunas = "COUNT(*) total";
+            $ordem = "";
+        }
+        
+        $query = "SELECT $colunas FROM LOCALIZAPESSOA L 
+                    INNER JOIN PESSOA P ON (L.codpes = P.codpes) 
                     WHERE (L.tipvinext = :vinculo 
                         AND L.codundclg = CONVERT(INT, :codundclgi) 
                         AND L.sitatl IN ('A', 'P')) 
-                    ORDER BY L.nompes";
+                    $ordem";
 
         $param = [
             'codundclgi'    => $codundclgi,


### PR DESCRIPTION
Fix #244 
Para que seja possível retornar no result o índice total
que corresponde ao número total de pessoas ativas no vínculo
:+1: 