### PR TITLE
Verificar se o arquivo zip foi descompactado corretamente.

### DIFF
--- a/src/Lattes.php
+++ b/src/Lattes.php
@@ -67,6 +67,10 @@ class Lattes
         $content = self::getZip($codpes);
         if($content){
             $xml = Uteis::unzip($content);
+            // Evitar salvar XML com 0 bytes
+            if (!$xml) {
+                return false;
+            }
             $xmlFile = fopen("{$to}/{$codpes}.xml", "w");
             fwrite($xmlFile, $xml); 
             fclose($xmlFile);


### PR DESCRIPTION
Fix #347 
Adicionada verificação (true/false) após retorno da descompactação do arquivo zip.