### PR TITLE
Adicionando condição query OrientandosConcluidos

### DIFF
--- a/resources/queries/Posgraduacao.listarOrientandosConcluidos.sql
+++ b/resources/queries/Posgraduacao.listarOrientandosConcluidos.sql
@@ -8,4 +8,5 @@ AND r.dtafimort IS NOT NULL
 AND n.dtafimare IS NOT NULL  
 AND a.dtadfapgm IS NOT NULL
 AND a.nivpgm IS NOT NULL
+AND a.starmtpgm IS NULL
 ORDER BY a.nivpgm


### PR DESCRIPTION
Correção para evitar que alunos que possuem Doutorado com um orientador e Mestrado com um orientador diferente, apareçam como pertencentes do mesmo orientador.