### PR TITLE
refactor de disciplinasOferecimento

### DIFF
--- a/src/Posgraduacao.php
+++ b/src/Posgraduacao.php
@@ -192,7 +192,10 @@ class Posgraduacao
                 AND o.dtacantur IS NULL --data-cancelamento-turma
                 AND o.dtafimofe > GETDATE() --data final futura
             ORDER BY o.sgldis";
-            /* data final futura exclui algumas disciplinas perdidas em OFERECIMENTO */
+            /* 
+            -self join com oferecimento para pegar somente as disciplinas listadas em R27DISMINCRE da área
+            -data final futura exclui algumas disciplinas perdidas em OFERECIMENTO 
+            */
 
         $param = ['codare' => $codare];
 


### PR DESCRIPTION
Em uso no replicado-ws, PR a fim de corrigir problemas ao listar disciplinas em oferecimento. Antes pegava por datas (dentro do semestre) o que não era legal. Agora pega da lista de disciplinas credenciadas na área, as que estão em oferecimento e ainda não finalizadas.