### PR TITLE
corrigindo função deprecada do php

### DIFF
--- a/src/Bempatrimoniado.php
+++ b/src/Bempatrimoniado.php
@@ -9,7 +9,7 @@ class Bempatrimoniado extends ReplicadoBase
 
     /**
      * Método que consulta a tebela BEMPATRIMONIADO e retona todos os campos
-     * @param Integer $numpat : Número de patrimônio
+     * @param string $numpat : Número de patrimônio
      * @param array $fields : colunas usados no select
      * @return array: campos da tabela BEMPATRIMONIADO
      */
@@ -37,12 +37,12 @@ class Bempatrimoniado extends ReplicadoBase
 
     /**
      * Retorna todos bens patrimoniados ativos (com opção de filtros e buscas)
-     *  
+     *
      * @param array $filtros (default) - stabem => 'Ativo'
      * @param array $buscas (opcional) - campo_tabela => valor
      * @param array $tipos (opcional) - campo_tabela => tipo (ex.: codpes => int)
      * @param integer $limite (default) - 2000
-     * 
+     *
      * @return array Retorna todos os campos da tabela BEMPATRIMONIADO
      */
     protected static function _ativos(array $filtros = [], array $buscas = [], array $tipos = [], int $limite = 2000)
@@ -56,18 +56,18 @@ class Bempatrimoniado extends ReplicadoBase
         $result = Bempatrimoniado::dump($numpat);
         if (isset($result) && in_array($result['coditmmat'],self::$BEM_INFORMATICAS)) {
             return true;
-        } 
+        }
         return false;
     }
 
     /**
      * Retorna todos bens patrimoniados (com opção de filtros e buscas)
-     *  
+     *
      * @param array $filtros (opcional) - campo_tabela => valor
      * @param array $buscas (opcional) - campo_tabela => valor
      * @param array $tipos (opcional) - campo_tabela => tipo (ex.: codpes => int)
      * @param integer $limite (default) - 2000
-     * 
+     *
      * @return array Retorna todos os campos da tabela BEMPATRIMONIADO
      */
     protected static function _bens(array $filtros = [], array $buscas = [], array $tipos = [], int $limite = 2000)
@@ -78,7 +78,7 @@ class Bempatrimoniado extends ReplicadoBase
         $query .= $filtros_buscas[0];
         // Define os parâmetros para cláusula WHERE
         $params = $filtros_buscas[1];
-    
+
         return DB::fetchAll($query, $params);
     }
 }

--- a/src/Beneficio.php
+++ b/src/Beneficio.php
@@ -23,7 +23,7 @@ class Beneficio extends ReplicadoBase
     /**
      * Retorna a lista de monitores da sala Pró-Aluno
      *
-     * @param Array $codigoSalaMonitor
+     * @param string $codigoSalaMonitor
      * @return Array
      * @author Leandro Ramos, em 28/4/2025
      */
@@ -41,10 +41,6 @@ class Beneficio extends ReplicadoBase
             "Beneficio.listarMonitoresProAluno.sql",
             $replaces
         );
-
-        $param = [
-            "codslamon" => $codigoSalaMonitor,
-        ];
 
         return DB::fetchAll($query);
     }

--- a/src/DB.php
+++ b/src/DB.php
@@ -5,7 +5,6 @@ namespace Uspdev\Replicado;
 use PDO;
 use SplFileInfo;
 use Throwable;
-use Uspdev\Cache\Cache;
 use Uspdev\Replicado\Replicado as Config;
 
 class DB
@@ -100,7 +99,7 @@ class DB
         $query = SELF::automaticReplaces($query);
         $stmt = SELF::getInstance()->prepare($query);
         foreach ($param as $campo => $valor) {
-            $valor = $config->sybase ? utf8_decode($valor) : $valor;
+            $valor = $config->sybase ? mb_convert_encoding($valor, "ISO-8859-1", "UTF-8") : $valor;
             $stmt->bindValue(":$campo", $valor);
             if ($config->debugLevel >= 2) {
                 $queryLog = str_replace(":$campo", $valor, $queryLog ?? $query);

--- a/src/Financeiro.php
+++ b/src/Financeiro.php
@@ -7,7 +7,7 @@ class Financeiro extends ReplicadoBase
      /**
      * Método que retorna os centros de despesas.
      * Utiliza o REPLICADO_CODUNDCLG do .env
-     * 
+     *
      * @param empty
      * @return array
      * @author Victor de O. Marinho <victor.oliveira.marinho@usp.br>
@@ -18,7 +18,7 @@ class Financeiro extends ReplicadoBase
         $query = "SELECT etrhie FROM CENTRODESPHIERARQUIA
                     WHERE dtadtv IS NULL
                     AND codunddsp IN ({$unidades})";
-                          
+
         return DB::fetchAll($query);
     }
 

--- a/src/Graduacao.php
+++ b/src/Graduacao.php
@@ -33,10 +33,10 @@ class Graduacao extends ReplicadoBase
      * Se informado parteNome, será usado para fazer uma busca fonética no nome.
      * Substitui o método ativos()
      *
-     * @param Int $codCur (opcional)
+     * @param int $codCur (opcional)
      * @param Int $anoIngresso (opcional)
-     * @param String $parteNome (opcional)
-     * @return Array codpes, nompes, codema, codcur, nomcur, codhab, nomhab, dtainivin
+     * @param string $parteNome (opcional)
+     * @return array codpes, nompes, codema, codcur, nomcur, codhab, nomhab, dtainivin
      * @author Masaki K Neto, em 13/10/2021, #475
      */
     protected static function _listarAtivos($codCur = null, $anoIngresso = null, $parteNome = null)
@@ -78,7 +78,7 @@ class Graduacao extends ReplicadoBase
     /**
      * Retorna contagem de alunos ativos na unidade
      *
-     * @return Integer
+     * @return int
      * @author Masaki K Neto, em 13/10/2021, #475
      */
     protected static function _contarAtivos()
@@ -98,7 +98,7 @@ class Graduacao extends ReplicadoBase
      * Caso o aluno não esteja cursando, retorna array vazio
      * Substitui método curso
      *
-     * @param Int $codpes
+     * @param int $codpes
      * @return Array (codpes, nompes, codcur, nomcur, codhab, nomhab, dtainivin, codcurgrd)
      * @author Masakik, adaptado em 8/11/2022
      */
@@ -443,7 +443,7 @@ class Graduacao extends ReplicadoBase
     protected static function _contarAtivosPorGenero($sexpes, $codcur = null)
     {
         $unidades = getenv('REPLICADO_CODUNDCLG');
-        $query = "SELECT COUNT (DISTINCT L.codpes) 
+        $query = "SELECT COUNT (DISTINCT L.codpes)
                   FROM LOCALIZAPESSOA L
                       INNER JOIN PESSOA P ON P.codpes = L.codpes
                       INNER JOIN HABILPROGGR H ON H.codpes = L.codpes
@@ -665,7 +665,7 @@ class Graduacao extends ReplicadoBase
      * @return Array
      * @author Masaki K Neto em 17/02/2022
      **/
-    protected static function _listarDisciplinasAluno(int $codpes, int $codpgm = null, array $rstfim = ['A', 'RN', 'RA', 'RF'])
+    protected static function _listarDisciplinasAluno(int $codpes, int|null $codpgm, array $rstfim = ['A', 'RN', 'RA', 'RF'])
     {
         $query = DB::getQuery('Graduacao.listarDisciplinasAluno.sql');
         $param['codpes'] = $codpes;
@@ -702,8 +702,8 @@ class Graduacao extends ReplicadoBase
      *
      * Método comum que é chamado por obterMediaPonderadaLimpa e obterMediaPonderadaSuja.
      *
-     * @param Integer $codpes
-     * @param Integer $codpgm Código que identifica cada programa do aluno.
+     * @param Int $codpes
+     * @param Int|Null $codpgm Código que identifica cada programa do aluno.
      * @param Array $rstfim ['A'] - média limpa ou ['A','RN','RA','RF'] - média suja (default)
      * @return Float Arredondado para 1 casa decimal.
      * @author gabrielareisg em 14/06/2021
@@ -711,7 +711,7 @@ class Graduacao extends ReplicadoBase
      * @author modificado por Masakik em 18/2/2022
      * @see self::_listarDisciplinasAluno()
      */
-    protected static function _obterMediaPonderada(int $codpes, int $codpgm = null, array $rstfim = ['A', 'RN', 'RA', 'RF'])
+    protected static function _obterMediaPonderada(int $codpes, int|null $codpgm, array $rstfim = ['A', 'RN', 'RA', 'RF'])
     {
         $result = self::_listarDisciplinasAluno($codpes, $codpgm, $rstfim);
 
@@ -735,12 +735,12 @@ class Graduacao extends ReplicadoBase
      * OBS.: Este método não utiliza o cache na configuração padrão pois o retorno ocupa poucos bytes.
      * Deve modificar a configuração do cache se for conveniente.
      *
-     * @param Integer $codpes
-     * @param Integer $codpgm Código que identifica cada programa do aluno.
+     * @param int $codpes
+     * @param int|null $codpgm Código que identifica cada programa do aluno.
      * @return string
      * @author thiagogomesverissimo em 21/11/2021
      */
-    protected static function _obterMediaPonderadaLimpa(int $codpes, int $codpgm = null)
+    protected static function _obterMediaPonderadaLimpa(int $codpes, int|null $codpgm)
     {
         return self::_obterMediaPonderada($codpes, $codpgm, ['A']);
     }
@@ -755,12 +755,12 @@ class Graduacao extends ReplicadoBase
      * OBS.: Este método não utiliza o cache na configuração padrão pois o retorno ocupa poucos bytes.
      * Deve modificar a configuração do cache se for conveniente.
      *
-     * @param Integer $codpes
-     * @param Integer $codpgm Código que identifica cada programa do aluno.
+     * @param int $codpes
+     * @param int $codpgm Código que identifica cada programa do aluno.
      * @return string
      * @author thiagogomesverissimo em 21/11/2021
      */
-    protected static function _obterMediaPonderadaSuja(int $codpes, int $codpgm = null)
+    protected static function _obterMediaPonderadaSuja(int $codpes, int|null $codpgm)
     {
         return self::_obterMediaPonderada($codpes, $codpgm, ['A', 'RN', 'RA', 'RF']);
     }
@@ -801,7 +801,7 @@ class Graduacao extends ReplicadoBase
      * Retorna lista com os cursos de graduação da unidade.
      *
      * @return Array
-     * @author Alessandro Costa de Oliveira, em 01/04/2026 
+     * @author Alessandro Costa de Oliveira, em 01/04/2026
      */
     protected static function _listarCursos()
     {
@@ -840,7 +840,7 @@ class Graduacao extends ReplicadoBase
         $query = " SELECT LOCALIZAPESSOA.* FROM LOCALIZAPESSOA";
         $query .= " WHERE LOCALIZAPESSOA.tipvin = 'ALUNOGR' AND LOCALIZAPESSOA.codundclg = convert(int,:codundclgi)";
         if (!is_null($parteNome)) {
-            $parteNome = trim(utf8_decode(Uteis::removeAcentos($parteNome)));
+            $parteNome = trim(mb_convert_encoding(Uteis::removeAcentos($parteNome), "ISO-8859-1", "UTF-8"));
             $parteNome = strtoupper(str_replace(' ', '%', $parteNome));
             $query .= " AND nompesfon LIKE :parteNome";
             $param['parteNome'] = '%' . Uteis::fonetico($parteNome) . '%';

--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -10,8 +10,8 @@ class Pessoa extends ReplicadoBase
      *
      * O campos $fields é opcional.
      *
-     * @param Integer $codpes
-     * @param Array $fields
+     * @param int $codpes
+     * @param array $fields
      * @return Array
      */
     protected static function _dump(int $codpes, array $fields = ['*'])
@@ -150,7 +150,7 @@ class Pessoa extends ReplicadoBase
      * @author Marcelo A K Fontana, atualizado em 01/10/2024
      * @author Marcelo A K Fontana, atualizado em 22/11/2024
      */
-    protected static function _procurarPorNome(string $nome, bool $fonetico = true, bool $ativos = true, string $tipvin = null, string $codundclgs = null, string $tipvinext = null)
+    protected static function _procurarPorNome(string $nome, bool $fonetico = true, bool $ativos = true, string|null $tipvin, string|null $codundclgs, string|null $tipvinext)
     {
         if ($fonetico) {
             $nome = Uteis::fonetico($nome);
@@ -692,7 +692,7 @@ class Pessoa extends ReplicadoBase
     /**
      * Método para retornar data de nascimento de uma pessoa, com base no seu número USP ($codpes)
      *
-     * @param Integer $codpes
+     * @param int $codpes
      * @return void
      */
     protected static function _nascimento($codpes)
@@ -805,7 +805,7 @@ class Pessoa extends ReplicadoBase
      * @author Refatorado por @gabrielareisg - 30/04/2021 - issue #425
      *
      */
-    protected static function _listarDocentes(string $codset_list = null, string $sitatl_list = 'A')
+    protected static function _listarDocentes(string|null $codset_list, string $sitatl_list = 'A')
     {
         $unidades = getenv('REPLICADO_CODUNDCLG');
         $where_setores = $codset_list ? "AND L.codset IN ({$codset_list})" : '';
@@ -1019,7 +1019,6 @@ class Pessoa extends ReplicadoBase
      */
     protected static function _retornarEmailUsp(int $codpes)
     {
-        $unidades = getenv('REPLICADO_CODUNDCLG');
         $query = DB::getQuery('Pessoa.retornarEmailUsp.sql');
 
         $param = [
@@ -1260,7 +1259,7 @@ class Pessoa extends ReplicadoBase
      */
     protected static function _nome($nome)
     {
-        return self::_procurarPorNome($nome, false, false);
+        return self::_procurarPorNome($nome, false, false, false, false, false);
     }
 
     /**
@@ -1272,14 +1271,14 @@ class Pessoa extends ReplicadoBase
      */
     protected static function _nomeFonetico($nome)
     {
-        return self::_procurarPorNome($nome, true, false);
+        return self::_procurarPorNome($nome, true, false, false, false, false);
     }
 
     /**
      * (deprecated) Método que lista siglas dos vínculos ativos de uma pessoa, em uma dada unidade
      *
-     * @param Integer $codpes
-     * @param Integer (opt) $codundclgi
+     * @param int $codpes
+     * @param int (opt) $codundclgi
      * @return array
      * @author Alessandro Costa de Oliveira em 04/03/2021. Bug fix para aceitar a chamada sem o código de unidade
      * @deprecated em favor de obterSiglasVinculosAtivos, em 25/06/2021 - @thiagogomesverissimo
@@ -1292,8 +1291,8 @@ class Pessoa extends ReplicadoBase
     /**
      * (deprecated) Método para retornar siglas dos setores que uma pessoa tem vínculo
      *
-     * @param Integer $codpes
-     * @param Integer $codundclgi
+     * @param int $codpes
+     * @param int $codundclgi
      * @return array
      * @author Alessandro Costa de Oliveira em 04/03/2021. Bug fix para aceitar a chamada sem o código de unidade
      * @deprecated em favor de obterSiglasSetoresAtivos, em 25/06/2021 - @thiagogomesverissimo
@@ -1306,7 +1305,7 @@ class Pessoa extends ReplicadoBase
     /**
      * (deprecated) Método que recebe número USP para retornar email USP da pessoa
      *
-     * @param Integer $codpes
+     * @param int $codpes
      * @return String
      * @deprecated em favor de retornarEmailUsp, em 25/06/2021 - @thiagogomesverissimo
      */
@@ -1335,7 +1334,7 @@ class Pessoa extends ReplicadoBase
      * Também Docente Aposentado
      *
      * @param Integer $codpes
-     * @param (opt) $codundclgi
+     * @param string $codundclgi
      * @deprecated em favor de listarVinculosSetores, em 19/09/2022 - @alecostaweb
      * @return array
      */

--- a/src/Posgraduacao.php
+++ b/src/Posgraduacao.php
@@ -166,7 +166,7 @@ class Posgraduacao extends ReplicadoBase
      * Uma mesma disciplina pode ser oferecida para mais de uma área
      * Modificado em 26/1/2022 de forma a não usar mais as datas de inicio/fim.
      * Agora usa as informações da tabela R27DISMINCRE
-     * 
+     *
      * @param int $codare Código da áreada PG.
      * @return array
      *
@@ -192,9 +192,9 @@ class Posgraduacao extends ReplicadoBase
                 AND o.dtacantur IS NULL --data-cancelamento-turma
                 AND o.dtafimofe > GETDATE() --data final futura
             ORDER BY o.sgldis";
-        /* 
+        /*
             -self join com oferecimento para pegar somente as disciplinas listadas em R27DISMINCRE da área
-            -data final futura exclui algumas disciplinas perdidas em OFERECIMENTO 
+            -data final futura exclui algumas disciplinas perdidas em OFERECIMENTO
             */
 
         $param = ['codare' => $codare];
@@ -312,13 +312,13 @@ class Posgraduacao extends ReplicadoBase
      * Retorna as áreas de concentração ativas dos programas de pós-graduação da unidade.
      * Se informado o código do curso (programa), retorna apenas as áreas deste curso.
      *
-     * @param int $codundclgi - código da Unidade
-     * @param int $codcur - código do curso de pós-graduação
+     * @param int|null $codundclgi - código da Unidade
+     * @param int|null $codcur - código do curso de pós-graduação
      * @return type
      *
      * por Erickson Zanon - czanon@usp.br
      */
-    protected static function _areasProgramas(int $codundclgi = null, int $codcur = null)
+    protected static function _areasProgramas(int|null $codundclgi, int|null $codcur)
     {
         if (!$codundclgi) {
             $codundclgi = getenv('REPLICADO_CODUNDCLG');
@@ -369,12 +369,12 @@ class Posgraduacao extends ReplicadoBase
      *  indexados pela área (codare).
      * Se codare não foi determinado, busca todas as áreas do programa.
      *
-     * @param Int $codundclgi - código da unidade
-     * @param Int $codcur - código do curso/programa
-     * @param Int $codare - código da área (opcional)
+     * @param int $codundclgi - código da unidade
+     * @param int $codcur - código do curso/programa
+     * @param int|null $codare - código da área (opcional)
      * @return Array
      */
-    protected static function _alunosPrograma(int $codundclgi, int $codcur, int $codare = null)
+    protected static function _alunosPrograma(int $codundclgi, int $codcur, int|null $codare)
     {
         // se $codare é null, seleciona todas
         if (!$codare) {
@@ -737,7 +737,7 @@ class Posgraduacao extends ReplicadoBase
 
         $query = DB::getQuery('Posgraduacao.listarDefesas.sql');
         $query = str_replace('__unidades__', getenv('REPLICADO_CODUNDCLG'), $query);
-        
+
         $param = [
             'inicio' => $intervalo['inicio'],
             'fim' => $intervalo['fim'],
@@ -831,7 +831,7 @@ class Posgraduacao extends ReplicadoBase
         $codclg = getenv('REPLICADO_CODUNDCLG');
 
         $query = "SELECT d.*
-                  FROM 
+                  FROM
                   (
                     SELECT MAX(numseqdis) AS numseqdis, sgldis
                     FROM dbo.DISCIPLINA
@@ -840,7 +840,7 @@ class Posgraduacao extends ReplicadoBase
                   JOIN AREA ON AREA.codare = d.codare
                   JOIN CURSO ON CURSO.codcur = AREA.codcur
                   WHERE CURSO.codclg IN ({$codclg})
-                    AND d.dtadtvdis IS NULL 
+                    AND d.dtadtvdis IS NULL
                   ORDER BY d.nomdis ASC";
 
         return DB::fetchAll($query);

--- a/src/Uteis.php
+++ b/src/Uteis.php
@@ -89,9 +89,9 @@ class Uteis
 
     public static function utf8_converter($array)
     {
-        array_walk_recursive($array, function (&$item, $key) {
+        array_walk_recursive($array, function (&$item) {
             if (!mb_detect_encoding($item, 'utf-8', true)) {
-                $item = utf8_encode($item);
+                $item = mb_convert_encoding($item, "ISO-8859-1", "UTF-8");
             }
         });
         return $array;
@@ -99,7 +99,7 @@ class Uteis
 
     public static function trim_recursivo($array)
     {
-        array_walk_recursive($array, function (&$item, $key) {
+        array_walk_recursive($array, function (&$item) {
             $item = trim($item);
         });
         return $array;
@@ -158,7 +158,7 @@ class Uteis
 
     /**
      * Gets the value of an environment variable. Supports boolean, empty and null.
-     * 
+     *
      * Adaptado de env() do Laravel
      *
      * @param string $key


### PR DESCRIPTION
    Corrigindo o erro "Implicitly marking parameter $xxx as nullable";
    Alterando a função "utf8_decode", que está obsoleta e será removida
    na versão 9 do php, para mb_convert_encoding.
    fix #613;