### PR TITLE
voltando atribuição default null e issue #617

### DIFF
--- a/src/Graduacao.php
+++ b/src/Graduacao.php
@@ -665,7 +665,7 @@ class Graduacao extends ReplicadoBase
      * @return Array
      * @author Masaki K Neto em 17/02/2022
      **/
-    protected static function _listarDisciplinasAluno(int $codpes, int|null $codpgm, array $rstfim = ['A', 'RN', 'RA', 'RF'])
+    protected static function _listarDisciplinasAluno(int $codpes, int|null $codpgm = null, array $rstfim = ['A', 'RN', 'RA', 'RF'])
     {
         $query = DB::getQuery('Graduacao.listarDisciplinasAluno.sql');
         $param['codpes'] = $codpes;
@@ -711,7 +711,7 @@ class Graduacao extends ReplicadoBase
      * @author modificado por Masakik em 18/2/2022
      * @see self::_listarDisciplinasAluno()
      */
-    protected static function _obterMediaPonderada(int $codpes, int|null $codpgm, array $rstfim = ['A', 'RN', 'RA', 'RF'])
+    protected static function _obterMediaPonderada(int $codpes, int|null $codpgm = null, array $rstfim = ['A', 'RN', 'RA', 'RF'])
     {
         $result = self::_listarDisciplinasAluno($codpes, $codpgm, $rstfim);
 
@@ -740,7 +740,7 @@ class Graduacao extends ReplicadoBase
      * @return string
      * @author thiagogomesverissimo em 21/11/2021
      */
-    protected static function _obterMediaPonderadaLimpa(int $codpes, int|null $codpgm)
+    protected static function _obterMediaPonderadaLimpa(int $codpes, int|null $codpgm = null)
     {
         return self::_obterMediaPonderada($codpes, $codpgm, ['A']);
     }
@@ -760,7 +760,7 @@ class Graduacao extends ReplicadoBase
      * @return string
      * @author thiagogomesverissimo em 21/11/2021
      */
-    protected static function _obterMediaPonderadaSuja(int $codpes, int|null $codpgm)
+    protected static function _obterMediaPonderadaSuja(int $codpes, int|null $codpgm = null)
     {
         return self::_obterMediaPonderada($codpes, $codpgm, ['A', 'RN', 'RA', 'RF']);
     }

--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -150,7 +150,7 @@ class Pessoa extends ReplicadoBase
      * @author Marcelo A K Fontana, atualizado em 01/10/2024
      * @author Marcelo A K Fontana, atualizado em 22/11/2024
      */
-    protected static function _procurarPorNome(string $nome, bool $fonetico = true, bool $ativos = true, string|null $tipvin, string|null $codundclgs, string|null $tipvinext)
+    protected static function _procurarPorNome(string $nome, bool $fonetico = true, bool $ativos = true, string|null $tipvin = null, string|null $codundclgs = null, string|null $tipvinext = null)
     {
         if ($fonetico) {
             $nome = Uteis::fonetico($nome);
@@ -805,7 +805,7 @@ class Pessoa extends ReplicadoBase
      * @author Refatorado por @gabrielareisg - 30/04/2021 - issue #425
      *
      */
-    protected static function _listarDocentes(string|null $codset_list, string $sitatl_list = 'A')
+    protected static function _listarDocentes(string|null $codset_list = null, string $sitatl_list = 'A')
     {
         $unidades = getenv('REPLICADO_CODUNDCLG');
         $where_setores = $codset_list ? "AND L.codset IN ({$codset_list})" : '';

--- a/src/Posgraduacao.php
+++ b/src/Posgraduacao.php
@@ -318,7 +318,7 @@ class Posgraduacao extends ReplicadoBase
      *
      * por Erickson Zanon - czanon@usp.br
      */
-    protected static function _areasProgramas(int|null $codundclgi, int|null $codcur)
+    protected static function _areasProgramas(int|null $codundclgi = null, int|null $codcur = null)
     {
         if (!$codundclgi) {
             $codundclgi = getenv('REPLICADO_CODUNDCLG');
@@ -374,7 +374,7 @@ class Posgraduacao extends ReplicadoBase
      * @param int|null $codare - código da área (opcional)
      * @return Array
      */
-    protected static function _alunosPrograma(int $codundclgi, int $codcur, int|null $codare)
+    protected static function _alunosPrograma(int $codundclgi, int $codcur, int|null $codare = null)
     {
         // se $codare é null, seleciona todas
         if (!$codare) {

--- a/src/Uteis.php
+++ b/src/Uteis.php
@@ -91,7 +91,7 @@ class Uteis
     {
         array_walk_recursive($array, function (&$item) {
             if (!mb_detect_encoding($item, 'utf-8', true)) {
-                $item = mb_convert_encoding($item, "ISO-8859-1", "UTF-8");
+                $item = mb_convert_encoding($item, "UTF-8", "ISO-8859-1");
             }
         });
         return $array;
@@ -141,7 +141,7 @@ class Uteis
      * @return Array formato ['yyymmdd', 'yyyymmdd']
      * @author Masaki K Neto, em algum dia de 2019
      */
-    public static function semestre(string|null $data_string)
+    public static function semestre(string|null $data_string = null)
     {
         $data = $data_string ? new \DateTime($data_string) : new \DateTime('now');
 


### PR DESCRIPTION
    Para os campos que tinham atribuição default null, ex.: int $x = null, e
    foi alterado para, int|null $x, agora ficou int|null $x = null.
    Foi corrigido a troca do tipo de enconding na classe Uteis, conforme
    issue 617.

    closes #613, closes #617